### PR TITLE
excluding dependabot created PRs from GitHub query

### DIFF
--- a/counter-generate-csv.sh
+++ b/counter-generate-csv.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 
-query='is:pr -label:dependencies created:>2022-10-01'
+# We exclude the PRs created by dependabot
+query='is:pr -author:app/dependabot created:>2022-10-01'
 
 #Spec: is "hacktoberfest" flag set? 
 label_hacktoberfest='\bhacktoberfest\b'


### PR DESCRIPTION
Previous GH query excluded PRs tagged as dependencies.
But this was too strict.
We are now excluding the PRs authored by dependabot in the GH query.
JQ further refines the query