### PR TITLE
Remove stapler from organization query

### DIFF
--- a/hacktoberfest-repositories.sh
+++ b/hacktoberfest-repositories.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 ## config
-query='org:jenkinsci org:jenkins-infra org:stapler topic:hacktoberfest fork:true'
+query='org:jenkinsci org:jenkins-infra topic:hacktoberfest fork:true'
 
 # csv files
 current_time=$(date "+%Y%m%d-%H%M%S")


### PR DESCRIPTION
There's no repository in the stapler org, that opted in hacktoberfest. Nor is there much activity in the stapler org nowadays, given the major projects have been transferred to the jenkinsci org.