### PR TITLE
Exclude renovate from search query

### DIFF
--- a/counter-generate-csv.sh
+++ b/counter-generate-csv.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 
-# We exclude the PRs created by dependabot
+# We exclude the PRs created by dependabot and renovate
 query='is:pr -author:app/dependabot -author:app/renovate created:>2022-10-01'
 
 #Spec: is "hacktoberfest" flag set? 

--- a/counter-generate-csv.sh
+++ b/counter-generate-csv.sh
@@ -2,7 +2,7 @@
 
 
 # We exclude the PRs created by dependabot
-query='is:pr -author:app/dependabot created:>2022-10-01'
+query='is:pr -author:app/dependabot -author:app/renovate created:>2022-10-01'
 
 #Spec: is "hacktoberfest" flag set? 
 label_hacktoberfest='\bhacktoberfest\b'


### PR DESCRIPTION
[renovate](https://github.com/marketplace/renovate) is a bot to manage and update dependencies, similar to dependabot, but outperforms it by miles, in terms of frontend dependency management, like NPM, yarn etc.

I don't think many repositories in the orgs use renovate, but I added it to jenkinsci/jenkins and a few other repositories, working with frontend components, therefore I'd like to see it excluded.